### PR TITLE
Fixed an issue where it was impossible to create an event if the edit…

### DIFF
--- a/EditEvents.ascx.cs
+++ b/EditEvents.ascx.cs
@@ -529,10 +529,12 @@ namespace DotNetNuke.Modules.Events
                 currentDate = currentDate.AddMinutes(iInterval - remainder);
             }
 
-            this.tpStartTime.TimeView.Interval = new TimeSpan(0, iInterval, 0);
             this.tpStartTime.SelectedDate = currentDate;
-            this.tpEndTime.TimeView.Interval = new TimeSpan(0, iInterval, 0);
             this.tpEndTime.SelectedDate = currentDate.AddMinutes(iInterval);
+
+            int pickerInterval = iInterval == 1440 ? 1439 : iInterval;
+            this.tpStartTime.TimeView.Interval = new TimeSpan(0, pickerInterval, 0);
+            this.tpEndTime.TimeView.Interval = new TimeSpan(0, pickerInterval, 0);
 
 
             // Can this event be moderated

--- a/Installation/ReleaseNotes/Release.07.00.02.txt
+++ b/Installation/ReleaseNotes/Release.07.00.02.txt
@@ -4,4 +4,5 @@
 <h3>BUG FIXES</h3>
 <ul>
 	<li>Casting errors due to the VB.net/C# conversion fixed</li>
+	<li>Fixed an issue where it was impossible to create an event if the edit interval was set to 1440</li>
 </ul>


### PR DESCRIPTION
Fixed an issue where it was impossible to create an event if the edit interval was set to 1440

### Description of PR...
changed the UI time picker to use 1439 instead of 1440 or it would endlessly try to add the same time which I guess is not permitted by design. This will then show a start of 00:00 and and end of 23:59 in a 24 hours system or 12:00am to 11:59pm in a 12 hours system.

## Changes made
- Corrected the issue
- tested
- updated release notes

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
Close #12
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/DNNCommunity/DNN.Events/pull/102?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/DNNCommunity/DNN.Events/pull/102'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>