### PR TITLE
Fixed issue with unselected categories and locations

### DIFF
--- a/Installation/ReleaseNotes/Release.07.00.02.txt
+++ b/Installation/ReleaseNotes/Release.07.00.02.txt
@@ -5,4 +5,6 @@
 <ul>
 	<li>Casting errors due to the VB.net/C# conversion fixed</li>
 	<li>Fixed an issue where it was impossible to create an event if the edit interval was set to 1440</li>
+	<li>Fixed an issue where it was impossible to view events after changing months when categories where enabled but none selected</li>
+	<li>Fixed an issue where it was impossible to view events after changing months when locations where enabled but none selected</li>
 </ul>

--- a/SubControls/SelectCategory.ascx.cs
+++ b/SubControls/SelectCategory.ascx.cs
@@ -51,7 +51,7 @@ namespace DotNetNuke.Modules.Events
             }
             else
             {
-                if (this.ddlCategories.CheckedItems.Count != this.ddlCategories.Items.Count)
+                if (this.ddlCategories.CheckedItems.Count > 0 && this.ddlCategories.CheckedItems.Count != this.ddlCategories.Items.Count)
                 {
                     foreach (var item in this.ddlCategories.CheckedItems)
                     {

--- a/SubControls/SelectLocation.ascx.cs
+++ b/SubControls/SelectLocation.ascx.cs
@@ -50,7 +50,7 @@ namespace DotNetNuke.Modules.Events
             }
             else
             {
-                if (this.ddlLocations.CheckedItems.Count != this.ddlLocations.Items.Count)
+                if (this.ddlLocations.CheckedItems.Count > 0 && this.ddlLocations.CheckedItems.Count != this.ddlLocations.Items.Count)
                 {
                     foreach (var item in this.ddlLocations.CheckedItems)
                     {


### PR DESCRIPTION
### Description of PR...
When categories or locations feature was enabled but no category or location was selected, it was impossible to change month and view other month issues, same when returning to original month

## Changes made
- Added a check to use -1 value if nothing was selected for the sql to work for both categories and locations

## PR Template Checklist

- [X] Fixes Bug
- [ ] Feature solution
- [ ] Other

## Please mark which issue is solved
Closes #15
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/DNNCommunity/DNN.Events/pull/103?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/DNNCommunity/DNN.Events/pull/103'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>