### PR TITLE
Fixing export event is throwing exception

### DIFF
--- a/Components/iCalProvider.cs
+++ b/Components/iCalProvider.cs
@@ -423,6 +423,12 @@ namespace DotNetNuke.Modules.Events
                     for (intYear = dtStartDate.Year - 1; intYear <= dtEndDate.Year; intYear++)
                     {
                         var yearDayLight = GetAdjustment(adjustments, intYear);
+                        
+                        if (yearDayLight == null)
+                        {
+                            continue;
+                        }
+                        
                         var daylightStart = yearDayLight.StartDate;
                         var daylightEnd = yearDayLight.EndDate;
                         if ((lastDSTStartDate == DateTime.MinValue || daylightStart > lastDSTStartDate) &&
@@ -439,6 +445,12 @@ namespace DotNetNuke.Modules.Events
                     for (intYear = dtStartDate.Year - 1; intYear <= dtEndDate.Year; intYear++)
                     {
                         var yearDayLight = GetAdjustment(adjustments, intYear);
+                        
+                        if (yearDayLight == null)
+                        {
+                            continue;
+                        }
+                        
                         var daylightStart = yearDayLight.StartDate;
                         var daylightEnd = yearDayLight.EndDate;
 


### PR DESCRIPTION
Fixing export event is throwing exception

### Description of PR...
yearDayLight  could be null depends on selected timezone and event date.

## Changes made
- continue for loop if yearDayLight  is null

## PR Template Checklist

- [x] Fixes Bug
- [ ] Feature solution
- [ ] Other


## Please mark which issue is solved
<!-- Type numbers directly after the #, it will show the issues with that number -->

Close #218